### PR TITLE
Fix econ-ark.org website metadata

### DIFF
--- a/REMARK.md
+++ b/REMARK.md
@@ -2,8 +2,14 @@
 # Econ-ARK website fields
 remark-version: "1.0" # required
 remark-name: Pandemic # required
+github_repo_url: https://github.com/econ-ark/Pandemic # required
 dashboards: # path to any dahsboards within the repo - optional
   - Code/Python/dashboard.ipynb
+identifiers-paper: # required for Replications; optional for Reproductions
+  - type: url
+    value: https://www.nber.org/papers/w27876
+  - type: doi
+    value: "https://doi.org/10.3386/w27876"
 
 tags: # Use the relavent tags
   - REMARK


### PR DESCRIPTION
- Add missing github_repo_url field for GitHub repository links
- Add identifiers-paper section for NBER paper access
- This fixes the 'No GitHub repository in metadata' error on econ-ark.org
- Ensures populate_remarks.py script works correctly for website generation